### PR TITLE
[SRCH-113] Removendo tag continue-on-error

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -72,7 +72,6 @@ jobs:
         run: echo ${{ secrets.maven_settings }} | base64 -d > ~/.m2/settings.xml
 
       - name: execute unit tests
-        continue-on-error: true
         run: ./mvnw $MAVEN_CLI_OPTS clean test -DskipITs=true
 
       - name: archive unit tests report


### PR DESCRIPTION
Removendo a tag continue-on-error do job unit-tests pois ao falhar na task o job não falhava com isso estavam realizados merges mesmo com sem que os testes na aplicação dessem sucesso